### PR TITLE
Project migration. Update data-provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 ### Removed
 
+## [2.0.0] - 2020-03-01
+### Changed
+- chore: Project migrated from @mocks-server/admin-api-client
+- chore(deps): [BREAKING CHANGE] Updated @data-provider/core to v2. Not compatible with projects using v1.
+- chore(deps): [BREAKING CHANGE] Moved @data-provider/axios dependency to peer-dependencies.
+- chore(umd): [BREAKING CHANGE] Renamed umd global variable to "mocksServerAdminApiClientDataProvider"
+
 ## [1.0.3] - 2020-01-26
 ### Changed
 - Update dependencies

--- a/README.md
+++ b/README.md
@@ -5,18 +5,24 @@
 [![NPM downloads][npm-downloads-image]][npm-downloads-url] [![License][license-image]][license-url]
 
 
-# Mocks-server administration api client
+# Mocks-server administration api client built with @data-provider
 
 This package contains methods for administrating the mocks-server _(through the [@mocks-server/plugin-admin-api](https://github.com/mocks-server/plugin-admin-api) RESTful API)_.
 
-Built using [@data-provider](https://github.com/data-provider), it can be used in Node.js, browsers, and is also compatible with @data-provider connectors, such as [@data-provider/connector-react](https://github.com/data-provider/connector-react), so can be easily integrated with frameworks.
+Built using [@data-provider](https://github.com/data-provider), it can be used in Node.js, browsers, and it is also compatible with other @data-provider packages, such as [@data-provider/react](https://github.com/data-provider/react), so can be easily integrated with frameworks.
+
+## Installation
+
+```bash
+npm i --save redux @data-provider/core @data-provider/axios @mocks-server/admin-api-client-data-provider
+```
 
 ## Usage with promises
 
 All methods described in the [Api](#api) (expect the `config` method) return Promises when executed:
 
 ```js
-import { about, settings } from "@mocks-server/admin-api-client";
+import { about, settings } from "@mocks-server/admin-api-client-data-provider";
 
 const example = async () => {
   const { version } = await about.read();
@@ -37,7 +43,7 @@ example();
 
 ## Usage with data-provider
 
-Exported properties `about`, `settings`, `behaviors`, `behaviorsModel`, `fixtures` and `fixturesModel` are [@data-provider/axios](https://github.com/data-provider/axios) providers, so can be used to define @data-provider Selectors. Methods can also be connected to frameworks using @data-provider connectors, such as [@data-provider/connector-react](https://github.com/data-provider/connector-react).
+Exported properties `about`, `settings`, `behaviors`, `behaviorsModel`, `fixtures` and `fixturesModel` are [@data-provider/axios](https://github.com/data-provider/axios) providers, so can be used to define @data-provider Selectors. Methods can also be connected to frameworks using another @data-provider packages, such as [@data-provider/react](https://github.com/data-provider/react).
 
 ## Api
 
@@ -58,7 +64,7 @@ By default, the client is configured to request to http://localhost:3100/admin, 
 You can change both the base url of the "@mocks-server", and the base api path of the "@mocks-server/plugin-admin-api" using the `config` method:
 
 ```js
-import { config } from "@mocks-server/admin-api-client";
+import { config } from "@mocks-server/admin-api-client-data-provider";
 
 config({
   apiPath: "/foo-admin",
@@ -73,19 +79,19 @@ Please read the [contributing guidelines](.github/CONTRIBUTING.md) and [code of 
 
 [plugin-admin-api-url]: https://github.com/mocks-server/plugin-admin-api
 
-[coveralls-image]: https://coveralls.io/repos/github/mocks-server/admin-api-client/badge.svg
-[coveralls-url]: https://coveralls.io/github/mocks-server/admin-api-client
-[travisci-image]: https://travis-ci.com/mocks-server/admin-api-client.svg?branch=master
-[travisci-url]: https://travis-ci.com/mocks-server/admin-api-client
-[last-commit-image]: https://img.shields.io/github/last-commit/mocks-server/admin-api-client.svg
-[last-commit-url]: https://github.com/mocks-server/admin-api-client/commits
-[license-image]: https://img.shields.io/npm/l/@mocks-server/admin-api-client.svg
-[license-url]: https://github.com/mocks-server/admin-api-client/blob/master/LICENSE
-[npm-downloads-image]: https://img.shields.io/npm/dm/@mocks-server/admin-api-client.svg
-[npm-downloads-url]: https://www.npmjs.com/package/@mocks-server/admin-api-client
-[npm-dependencies-image]: https://img.shields.io/david/mocks-server/admin-api-client.svg
-[npm-dependencies-url]: https://david-dm.org/mocks-server/admin-api-client
-[quality-gate-image]: https://sonarcloud.io/api/project_badges/measure?project=mocks-server-admin-api-client&metric=alert_status
-[quality-gate-url]: https://sonarcloud.io/dashboard?id=mocks-server-admin-api-client
-[release-image]: https://img.shields.io/github/release-date/mocks-server/admin-api-client.svg
-[release-url]: https://github.com/mocks-server/admin-api-client/releases
+[coveralls-image]: https://coveralls.io/repos/github/mocks-server/admin-api-client-data-provider/badge.svg
+[coveralls-url]: https://coveralls.io/github/mocks-server/admin-api-client-data-provider
+[travisci-image]: https://travis-ci.com/mocks-server/admin-api-client-data-provider.svg?branch=master
+[travisci-url]: https://travis-ci.com/mocks-server/admin-api-client-data-provider
+[last-commit-image]: https://img.shields.io/github/last-commit/mocks-server/admin-api-client-data-provider.svg
+[last-commit-url]: https://github.com/mocks-server/admin-api-client-data-provider/commits
+[license-image]: https://img.shields.io/npm/l/@mocks-server/admin-api-client-data-provider.svg
+[license-url]: https://github.com/mocks-server/admin-api-client-data-provider/blob/master/LICENSE
+[npm-downloads-image]: https://img.shields.io/npm/dm/@mocks-server/admin-api-client-data-provider.svg
+[npm-downloads-url]: https://www.npmjs.com/package/@mocks-server/admin-api-client-data-provider
+[npm-dependencies-image]: https://img.shields.io/david/mocks-server/admin-api-client-data-provider.svg
+[npm-dependencies-url]: https://david-dm.org/mocks-server/admin-api-client-data-provider
+[quality-gate-image]: https://sonarcloud.io/api/project_badges/measure?project=mocks-server-admin-api-client-data-provider&metric=alert_status
+[quality-gate-url]: https://sonarcloud.io/dashboard?id=mocks-server-admin-api-client-data-provider
+[release-image]: https://img.shields.io/github/release-date/mocks-server/admin-api-client-data-provider.svg
+[release-url]: https://github.com/mocks-server/admin-api-client-data-provider/releases

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "@mocks-server/admin-api-client",
-  "version": "1.0.3",
+  "name": "@mocks-server/admin-api-client-data-provider",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2269,24 +2269,23 @@
       }
     },
     "@data-provider/axios": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@data-provider/axios/-/axios-1.6.1.tgz",
-      "integrity": "sha512-TUukqUuUHQSUKBJFyhYiRwT34MLpBudT07JFAYgQZG9rv3Tyi5d5gH+obUHjpdMEywA4uumF62WA393LKu3viQ==",
+      "version": "2.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@data-provider/axios/-/axios-2.0.0-alpha.2.tgz",
+      "integrity": "sha512-P0wYphNGpGx4YThe0aOWkCQliYFivHARBoB/5PFySK9Z3fmp+UDb5AEmeXrCg5TbMDjMw87xwip0I9C8vB0lFg==",
+      "dev": true,
       "requires": {
-        "axios": "0.19.1",
+        "axios": "0.19.2",
         "axios-retry": "3.1.2",
-        "lodash": "4.17.15",
         "path-to-regexp": "6.1.0"
       }
     },
     "@data-provider/core": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@data-provider/core/-/core-1.8.0.tgz",
-      "integrity": "sha512-PUeLcCgVgFnI1JJFNW4Dxst/Y7b1Fe7rpKd+9KO3ufLNPhOJvFpUrbzAQJR6b923X4onG9wt4bQYpaet+fWvEA==",
+      "version": "2.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@data-provider/core/-/core-2.0.0-alpha.6.tgz",
+      "integrity": "sha512-+UmaK1quXD7FTgQe7ibxK93qfoniz2qHRk3w19jV2Rwx2K/WlQaoOLAK53rEFsnsxL6WhiTTqbD3X4AFxvNaEA==",
       "dev": true,
       "requires": {
-        "is-promise": "2.1.0",
-        "lodash": "4.17.15"
+        "is-promise": "2.1.0"
       }
     },
     "@jest/console": {
@@ -2987,9 +2986,10 @@
       "dev": true
     },
     "axios": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.1.tgz",
-      "integrity": "sha512-Yl+7nfreYKaLRvAvjNPkvfjnQHJM1yLBY3zhqAwcJSwR/6ETkanUgylgtIvkvz0xJ+p/vZuNw8X7Hnb7Whsbpw==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "dev": true,
       "requires": {
         "follow-redirects": "1.5.10"
       }
@@ -2998,6 +2998,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.1.2.tgz",
       "integrity": "sha512-+X0mtJ3S0mmia1kTVi1eA3DAC+oWnT2A29g3CpkzcBPMT6vJm+hn/WiV9wPt/KXLHVmg5zev9mWqkPx7bHMovg==",
+      "dev": true,
       "requires": {
         "is-retry-allowed": "^1.1.0"
       }
@@ -4648,6 +4649,7 @@
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
       "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "dev": true,
       "requires": {
         "debug": "=3.1.0"
       },
@@ -4656,6 +4658,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -4663,7 +4666,8 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -5948,7 +5952,8 @@
     "is-retry-allowed": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
+      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
+      "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
@@ -7134,7 +7139,8 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -7909,7 +7915,8 @@
     "path-to-regexp": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.1.0.tgz",
-      "integrity": "sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw=="
+      "integrity": "sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==",
+      "dev": true
     },
     "path-type": {
       "version": "3.0.0",
@@ -8149,6 +8156,16 @@
       "dev": true,
       "requires": {
         "util.promisify": "^1.0.0"
+      }
+    },
+    "redux": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
+      "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "symbol-observable": "^1.2.0"
       }
     },
     "regenerate": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@mocks-server/admin-api-client",
-  "version": "1.0.3",
-  "description": "Client of @mocks-server/plugin-admin-api",
+  "name": "@mocks-server/admin-api-client-data-provider",
+  "version": "2.0.0",
+  "description": "Client of @mocks-server/plugin-admin-api built with @data-provider",
   "keywords": [
     "mocks-server-plugin",
     "administration",
@@ -12,7 +12,7 @@
   ],
   "author": "Javier Brea",
   "license": "MIT",
-  "repository": "https://github.com/mocks-server/admin-api-client",
+  "repository": "https://github.com/mocks-server/admin-api-client-data-provider",
   "homepage": "https://www.mocks-server.org",
   "publishConfig": {
     "access": "public"
@@ -37,15 +37,16 @@
     "test:ci": "npm run build && npm run test:coverage && npm run test:e2e:ci"
   },
   "peerDependencies": {
-    "@data-provider/core": "^1.7.0"
+    "@data-provider/axios": "^2.0.0"
   },
   "dependencies": {
-    "@data-provider/axios": "1.6.1",
     "@mocks-server/admin-api-paths": "1.0.4"
   },
   "devDependencies": {
     "@babel/preset-env": "7.8.4",
-    "@data-provider/core": "1.8.0",
+    "redux": "4.0.5",
+    "@data-provider/core": "2.0.0-alpha.6",
+    "@data-provider/axios": "2.0.0-alpha.2",
     "@rollup/plugin-commonjs": "11.0.1",
     "@rollup/plugin-node-resolve": "7.0.0",
     "babel-eslint": "10.0.3",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -43,7 +43,7 @@ module.exports = [
     output: {
       file: "dist/index.umd.js",
       format: "umd",
-      name: "mocksServerAdminApiClient",
+      name: "mocksServerAdminApiClientDataProvider",
       globals: GLOBALS
     },
     plugins: [...BASE_PLUGINS, uglifier.uglify()]

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=mocks-server
-sonar.projectKey=mocks-server-admin-api-client
-sonar.projectVersion=1.0.3
+sonar.projectKey=mocks-server-admin-api-client-data-provider
+sonar.projectVersion=2.0.0
 
 sonar.javascript.file.suffixes=.js
 sonar.sourceEncoding=UTF-8

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,4 @@
-import { instances } from "@data-provider/core";
+import { providers } from "@data-provider/core";
 import { DEFAULT_BASE_PATH } from "@mocks-server/admin-api-paths";
 import TAG from "./tag";
 
@@ -13,7 +13,7 @@ export const config = options => {
     ...options
   };
 
-  instances.getByTag(TAG).config({
+  providers.getByTag(TAG).config({
     baseUrl: `${finalOptions.baseUrl}${finalOptions.apiPath}`
   });
 };

--- a/src/providers.js
+++ b/src/providers.js
@@ -1,65 +1,68 @@
 import { ABOUT, SETTINGS, BEHAVIORS, FIXTURES } from "@mocks-server/admin-api-paths";
-import { Api } from "@data-provider/axios";
+import { Axios } from "@data-provider/axios";
 
 import TAG from "./tag";
 
-export const about = new Api(ABOUT, {
-  defaultValue: {},
-  uuid: "about",
-  tags: [TAG]
+const initialState = data => ({
+  initialState: {
+    data,
+    loading: true
+  }
 });
 
-export const settings = new Api(SETTINGS, {
-  defaultValue: {},
-  uuid: "settings",
+export const about = new Axios("about", {
+  url: ABOUT,
+  tags: [TAG],
+  ...initialState({})
+});
+
+export const settings = new Axios("settings", {
+  url: SETTINGS,
   updateMethod: "patch",
-  tags: [TAG]
+  tags: [TAG],
+  ...initialState({})
 });
 
-export const behaviors = new Api(BEHAVIORS, {
-  defaultValue: [],
-  uuid: "behaviors",
-  tags: [TAG]
+export const behaviors = new Axios("behaviors", {
+  url: BEHAVIORS,
+  tags: [TAG],
+  ...initialState([])
 });
 
-export const behaviorsModel = new Api(`${BEHAVIORS}/:name`, {
-  defaultValue: {},
-  uuid: "behaviors-model",
-  tags: [TAG]
+export const behaviorsModel = new Axios("behaviors-model", {
+  url: `${BEHAVIORS}/:name`,
+  tags: [TAG],
+  ...initialState({})
 });
 
-behaviorsModel.addCustomQuery({
-  byName: name => ({
-    urlParams: {
-      name
-    }
-  })
-});
+behaviorsModel.addQuery("byName", name => ({
+  urlParams: {
+    name
+  }
+}));
 
 export const behavior = name => {
-  return behaviorsModel.byName(name);
+  return behaviorsModel.queries.byName(name);
 };
 
-export const fixtures = new Api(FIXTURES, {
-  defaultValue: [],
-  uuid: "fixtures",
-  tags: [TAG]
+export const fixtures = new Axios("fixtures", {
+  url: FIXTURES,
+  tags: [TAG],
+  ...initialState([])
 });
 
-export const fixturesModel = new Api(`${FIXTURES}/:id`, {
-  defaultValue: {},
-  uuid: "fixtures-model",
-  tags: [TAG]
+export const fixturesModel = new Axios("fixtures-model", {
+  url: `${FIXTURES}/:id`,
+  tags: [TAG],
+  ...initialState({})
 });
 
-fixturesModel.addCustomQuery({
-  byId: id => ({
-    urlParams: {
-      id
-    }
-  })
-});
+fixturesModel.addQuery("byId", id => ({
+  urlParams: {
+    id
+  }
+}));
 
 export const fixture = id => {
-  return fixturesModel.byId(id);
+  return fixturesModel.queries.byId(id);
 };

--- a/test-e2e/browser/package-lock.json
+++ b/test-e2e/browser/package-lock.json
@@ -180,6 +180,15 @@
         "@types/yargs": "^13.0.0"
       }
     },
+    "@samverschueren/stream-to-observable": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
+      "integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
+      "dev": true,
+      "requires": {
+        "any-observable": "^0.3.0"
+      }
+    },
     "@sheerun/mutationobserver-shim": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz",
@@ -526,6 +535,12 @@
         "uri-js": "^4.2.2"
       }
     },
+    "ansi-escapes": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+      "dev": true
+    },
     "ansi-regex": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -540,6 +555,12 @@
       "requires": {
         "color-convert": "^1.9.0"
       }
+    },
+    "any-observable": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
+      "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
+      "dev": true
     },
     "arch": {
       "version": "2.1.1",
@@ -579,13 +600,10 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.10"
-      }
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
+      "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
@@ -681,10 +699,19 @@
       "dev": true
     },
     "ci-info": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-      "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^2.0.0"
+      }
     },
     "cli-spinners": {
       "version": "0.1.2",
@@ -859,66 +886,216 @@
       }
     },
     "cypress": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.8.3.tgz",
-      "integrity": "sha512-I9L/d+ilTPPA4vq3NC1OPKmw7jJIpMKNdyfR8t1EXYzYCjyqbc59migOm1YSse/VRbISLJ+QGb5k4Y3bz2lkYw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-4.1.0.tgz",
+      "integrity": "sha512-FFV8pS9iuriSX4M9rna6awJUhiqozZD1D5z5BprCUJoho1ctbcgpkEUIUnqxli2OwjQqVz07egO+iqoGL+tw7g==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "0.4.1",
         "@cypress/xvfb": "1.2.4",
         "@types/sizzle": "2.3.2",
         "arch": "2.1.1",
-        "bluebird": "3.5.0",
-        "cachedir": "1.3.0",
+        "bluebird": "3.7.2",
+        "cachedir": "2.3.0",
         "chalk": "2.4.2",
         "check-more-types": "2.24.0",
-        "commander": "2.15.1",
+        "commander": "4.1.0",
         "common-tags": "1.8.0",
-        "debug": "3.2.6",
+        "debug": "4.1.1",
         "eventemitter2": "4.1.2",
-        "execa": "0.10.0",
+        "execa": "1.0.0",
         "executable": "4.1.1",
         "extract-zip": "1.6.7",
-        "fs-extra": "5.0.0",
-        "getos": "3.1.1",
-        "is-ci": "1.2.1",
+        "fs-extra": "8.1.0",
+        "getos": "3.1.4",
+        "is-ci": "2.0.0",
         "is-installed-globally": "0.1.0",
         "lazy-ass": "1.6.0",
-        "listr": "0.12.0",
+        "listr": "0.14.3",
         "lodash": "4.17.15",
-        "log-symbols": "2.2.0",
+        "log-symbols": "3.0.0",
         "minimist": "1.2.0",
         "moment": "2.24.0",
-        "ramda": "0.24.1",
+        "ospath": "1.2.2",
+        "pretty-bytes": "5.3.0",
+        "ramda": "0.26.1",
         "request": "2.88.0",
         "request-progress": "3.0.0",
-        "supports-color": "5.5.0",
+        "supports-color": "7.1.0",
         "tmp": "0.1.0",
-        "untildify": "3.0.3",
+        "untildify": "4.0.0",
         "url": "0.11.0",
         "yauzl": "2.10.0"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
         "bluebird": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
+          "version": "3.7.2",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+          "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+          "dev": true
+        },
+        "cachedir": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.3.0.tgz",
+          "integrity": "sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==",
           "dev": true
         },
         "commander": {
-          "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.0.tgz",
+          "integrity": "sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw==",
           "dev": true
         },
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        },
+        "listr": {
+          "version": "0.14.3",
+          "resolved": "https://registry.npmjs.org/listr/-/listr-0.14.3.tgz",
+          "integrity": "sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "@samverschueren/stream-to-observable": "^0.3.0",
+            "is-observable": "^1.1.0",
+            "is-promise": "^2.1.0",
+            "is-stream": "^1.1.0",
+            "listr-silent-renderer": "^1.1.1",
+            "listr-update-renderer": "^0.5.0",
+            "listr-verbose-renderer": "^0.5.0",
+            "p-map": "^2.0.0",
+            "rxjs": "^6.3.3"
           }
+        },
+        "listr-update-renderer": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
+          "integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^1.1.3",
+            "cli-truncate": "^0.2.1",
+            "elegant-spinner": "^1.0.1",
+            "figures": "^1.7.0",
+            "indent-string": "^3.0.0",
+            "log-symbols": "^1.0.2",
+            "log-update": "^2.3.0",
+            "strip-ansi": "^3.0.1"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              }
+            },
+            "log-symbols": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+              "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+              "dev": true,
+              "requires": {
+                "chalk": "^1.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
+            }
+          }
+        },
+        "listr-verbose-renderer": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
+          "integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "cli-cursor": "^2.1.0",
+            "date-fns": "^1.27.2",
+            "figures": "^2.0.0"
+          },
+          "dependencies": {
+            "figures": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+              "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+              "dev": true,
+              "requires": {
+                "escape-string-regexp": "^1.0.5"
+              }
+            }
+          }
+        },
+        "log-symbols": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+          "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2"
+          }
+        },
+        "log-update": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
+          "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^3.0.0",
+            "cli-cursor": "^2.0.0",
+            "wrap-ansi": "^3.0.1"
+          }
+        },
+        "p-map": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+          "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+          "dev": true
+        },
+        "ramda": {
+          "version": "0.26.1",
+          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
+          "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "untildify": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+          "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+          "dev": true
         }
       }
     },
@@ -1011,13 +1188,13 @@
       "dev": true
     },
     "execa": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
-      "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
       "dev": true,
       "requires": {
         "cross-spawn": "^6.0.0",
-        "get-stream": "^3.0.0",
+        "get-stream": "^4.0.0",
         "is-stream": "^1.1.0",
         "npm-run-path": "^2.0.0",
         "p-finally": "^1.0.0",
@@ -1119,6 +1296,16 @@
         "pend": "~1.2.0"
       }
     },
+    "figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
+      }
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -1143,12 +1330,12 @@
       "dev": true
     },
     "fs-extra": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
+        "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
         "universalify": "^0.1.0"
       }
@@ -1160,18 +1347,21 @@
       "dev": true
     },
     "get-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-      "dev": true
-    },
-    "getos": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/getos/-/getos-3.1.1.tgz",
-      "integrity": "sha512-oUP1rnEhAr97rkitiszGP9EgDVYnmchgFzfqRzSkgtfv7ai6tEi7Ko8GgjNXts7VLWEqrTWyhsOKLe5C5b/Zkg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
       "dev": true,
       "requires": {
-        "async": "2.6.1"
+        "pump": "^3.0.0"
+      }
+    },
+    "getos": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/getos/-/getos-3.1.4.tgz",
+      "integrity": "sha512-UORPzguEB/7UG5hqiZai8f0vQ7hzynMQyJLxStoQ8dPGAcmgsfXOPA4iE/fGtweHYkK+z4zc9V0g+CIFRf5HYw==",
+      "dev": true,
+      "requires": {
+        "async": "^3.1.0"
       }
     },
     "getpass": {
@@ -1300,12 +1490,12 @@
       "dev": true
     },
     "is-ci": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
-      "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
       "dev": true,
       "requires": {
-        "ci-info": "^1.5.0"
+        "ci-info": "^2.0.0"
       }
     },
     "is-finite": {
@@ -1317,6 +1507,12 @@
         "number-is-nan": "^1.0.0"
       }
     },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
     "is-installed-globally": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
@@ -1325,6 +1521,23 @@
       "requires": {
         "global-dirs": "^0.1.0",
         "is-path-inside": "^1.0.0"
+      }
+    },
+    "is-observable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
+      "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "^1.1.0"
+      },
+      "dependencies": {
+        "symbol-observable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+          "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+          "dev": true
+        }
       }
     },
     "is-path-inside": {
@@ -1972,6 +2185,12 @@
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
+    "ospath": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
+      "integrity": "sha1-EnZjl3Sj+O8lcvf+QoDg6kVQwHs=",
+      "dev": true
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -2021,6 +2240,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
+    "pretty-bytes": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
+      "integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg==",
       "dev": true
     },
     "pretty-format": {
@@ -2184,6 +2409,33 @@
         "request-promise-core": "1.1.3",
         "stealthy-require": "^1.1.1",
         "tough-cookie": "^2.3.3"
+      }
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "dependencies": {
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+          "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        }
       }
     },
     "rimraf": {
@@ -2383,6 +2635,50 @@
       "integrity": "sha1-Rb8dny19wJvtgfHDB8Qw5ouEz/4=",
       "dev": true
     },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        }
+      }
+    },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
@@ -2557,6 +2853,33 @@
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
+      }
+    },
+    "wrap-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
+      "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
+      "dev": true,
+      "requires": {
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
       }
     },
     "wrappy": {

--- a/test-e2e/browser/package.json
+++ b/test-e2e/browser/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@testing-library/cypress": "5.0.2",
-    "cypress": "3.8.3",
+    "cypress": "4.1.0",
     "start-server-and-test": "1.10.8"
   }
 }

--- a/test-e2e/browser/react-app/config-overrides.js
+++ b/test-e2e/browser/react-app/config-overrides.js
@@ -7,7 +7,22 @@ module.exports = config => {
   );
   config.resolve.alias = {
     ...config.resolve.alias,
-    "mocks-server-admin-api-client": path.resolve(__dirname, "..", "..", "..")
+    "@mocks-server/admin-api-client-data-provider": path.resolve(
+      __dirname,
+      "..",
+      "..",
+      "..",
+      "dist",
+      "index.cjs"
+    ),
+    "@data-provider/core": path.resolve(
+      __dirname,
+      "node_modules",
+      "@data-provider",
+      "core",
+      "dist",
+      "core.cjs"
+    )
   };
   return config;
 };

--- a/test-e2e/browser/react-app/package-lock.json
+++ b/test-e2e/browser/react-app/package-lock.json
@@ -1044,14 +1044,35 @@
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-10.1.0.tgz",
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
-    "@data-provider/connector-react": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@data-provider/connector-react/-/connector-react-1.4.2.tgz",
-      "integrity": "sha512-cSbE9DN19yE9n0zxNd/R7Lr8Zr3od2VN6cYPVAzOj0oI2uEiYTqnpBnYlt/gj6dQCqvrQ7JfFaRPYINsX/WSSw==",
+    "@data-provider/axios": {
+      "version": "2.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@data-provider/axios/-/axios-2.0.0-alpha.2.tgz",
+      "integrity": "sha512-P0wYphNGpGx4YThe0aOWkCQliYFivHARBoB/5PFySK9Z3fmp+UDb5AEmeXrCg5TbMDjMw87xwip0I9C8vB0lFg==",
       "requires": {
-        "hoist-non-react-statics": "3.3.1",
-        "lodash": "4.17.15"
+        "axios": "0.19.2",
+        "axios-retry": "3.1.2",
+        "path-to-regexp": "6.1.0"
+      },
+      "dependencies": {
+        "path-to-regexp": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.1.0.tgz",
+          "integrity": "sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw=="
+        }
       }
+    },
+    "@data-provider/core": {
+      "version": "2.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@data-provider/core/-/core-2.0.0-alpha.6.tgz",
+      "integrity": "sha512-+UmaK1quXD7FTgQe7ibxK93qfoniz2qHRk3w19jV2Rwx2K/WlQaoOLAK53rEFsnsxL6WhiTTqbD3X4AFxvNaEA==",
+      "requires": {
+        "is-promise": "2.1.0"
+      }
+    },
+    "@data-provider/react": {
+      "version": "1.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@data-provider/react/-/react-1.0.0-alpha.2.tgz",
+      "integrity": "sha512-0EE3X3Cw+N2fkIbKKO00HsKmb2qCYkM48JwTpgh4/wT/oWUz8I82L20YXWLTxVibvsnI0BZmgetYT5gfNE546g=="
     },
     "@hapi/address": {
       "version": "2.1.2",
@@ -2155,6 +2176,45 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+    },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "axios-retry": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.1.2.tgz",
+      "integrity": "sha512-+X0mtJ3S0mmia1kTVi1eA3DAC+oWnT2A29g3CpkzcBPMT6vJm+hn/WiV9wPt/KXLHVmg5zev9mWqkPx7bHMovg==",
+      "requires": {
+        "is-retry-allowed": "^1.1.0"
+      }
     },
     "axobject-query": {
       "version": "2.1.1",
@@ -5927,9 +5987,9 @@
       }
     },
     "hoist-non-react-statics": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
-      "integrity": "sha512-wbg3bpgA/ZqWrZuMOeJi8+SKMhr7X9TesL/rXMjTzh0p0JUBo3II8DHboYbuIXWRlttrUFxwcu/5kygrCw8fJw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
       "requires": {
         "react-is": "^16.7.0"
       }
@@ -6511,6 +6571,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
       "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
+    },
+    "is-retry-allowed": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
     },
     "is-root": {
       "version": "2.1.0",
@@ -10682,6 +10747,18 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.11.0.tgz",
       "integrity": "sha512-gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw=="
     },
+    "react-redux": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.0.tgz",
+      "integrity": "sha512-EvCAZYGfOLqwV7gh849xy9/pt55rJXPwmYvI4lilPM5rUT/1NxuuN59ipdBksRVSvz0KInbPnp4IfoXJXCqiDA==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "hoist-non-react-statics": "^3.3.0",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.9.0"
+      }
+    },
     "react-scripts": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-3.3.1.tgz",
@@ -10793,6 +10870,15 @@
       "integrity": "sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
       "requires": {
         "minimatch": "3.0.4"
+      }
+    },
+    "redux": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
+      "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "symbol-observable": "^1.2.0"
       }
     },
     "regenerate": {
@@ -12441,6 +12527,11 @@
         "unquote": "~1.1.1",
         "util.promisify": "~1.0.0"
       }
+    },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/test-e2e/browser/react-app/package.json
+++ b/test-e2e/browser/react-app/package.json
@@ -3,11 +3,15 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@data-provider/connector-react": "1.4.2",
+    "@data-provider/axios": "2.0.0-alpha.2",
+    "@data-provider/core": "2.0.0-alpha.6",
+    "@data-provider/react": "1.0.0-alpha.2",
     "prop-types": "15.7.2",
     "react": "16.12.0",
     "react-dom": "16.12.0",
-    "react-scripts": "3.3.1"
+    "react-redux": "7.2.0",
+    "react-scripts": "3.3.1",
+    "redux": "4.0.5"
   },
   "scripts": {
     "start": "react-app-rewired start",

--- a/test-e2e/browser/react-app/public/index.html
+++ b/test-e2e/browser/react-app/public/index.html
@@ -6,7 +6,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="admin-api-client react app tests"
+      content="admin-api-client-data-provider react app tests"
     />
     <title>React App</title>
   </head>

--- a/test-e2e/browser/react-app/src/App.js
+++ b/test-e2e/browser/react-app/src/App.js
@@ -1,22 +1,38 @@
 import React from "react";
-import "./App.css";
+import { Provider } from "react-redux";
+import { createStore, combineReducers } from "redux";
+import { storeManager } from "@data-provider/core";
+
 import About from "./modules/about";
 import Settings from "./modules/settings";
 import Behaviors from "./modules/behaviors";
 import CurrentBehavior from "./modules/current-behavior";
 import Fixtures from "./modules/fixtures";
 
+import "./App.css";
+
+const store = createStore(
+  combineReducers({
+    dataProviders: storeManager.reducer
+  }),
+  window && window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+);
+
+storeManager.setStore(store, "dataProviders");
+
 function App() {
   return (
-    <div className="App">
-      <header className="App-header">
-        <About />
-        <Settings />
-        <Behaviors />
-        <CurrentBehavior />
-        <Fixtures />
-      </header>
-    </div>
+    <Provider store={store}>
+      <div className="App">
+        <header className="App-header">
+          <About />
+          <Settings />
+          <Behaviors />
+          <CurrentBehavior />
+          <Fixtures />
+        </header>
+      </div>
+    </Provider>
   );
 }
 

--- a/test-e2e/browser/react-app/src/modules/about/AboutController.js
+++ b/test-e2e/browser/react-app/src/modules/about/AboutController.js
@@ -1,10 +1,8 @@
-import { connect } from "@data-provider/connector-react";
-import { about } from "mocks-server-admin-api-client";
+import { withData } from "@data-provider/react";
+import { about } from "@mocks-server/admin-api-client-data-provider";
 
 import AboutView from "./AboutView";
 
-const AboutController = connect(() => ({
-  about: about.read.getters.value
-}))(AboutView);
+const AboutController = withData(about, "about")(AboutView);
 
 export default AboutController;

--- a/test-e2e/browser/react-app/src/modules/behaviors/BehaviorsController.js
+++ b/test-e2e/browser/react-app/src/modules/behaviors/BehaviorsController.js
@@ -1,10 +1,8 @@
-import { connect } from "@data-provider/connector-react";
-import { behaviors } from "mocks-server-admin-api-client";
+import { withData } from "@data-provider/react";
+import { behaviors } from "@mocks-server/admin-api-client-data-provider";
 
 import BehaviorsView from "./BehaviorsView";
 
-const BehaviorsController = connect(() => ({
-  behaviors: behaviors.read.getters.value
-}))(BehaviorsView);
+const BehaviorsController = withData(behaviors, "behaviors")(BehaviorsView);
 
 export default BehaviorsController;

--- a/test-e2e/browser/react-app/src/modules/current-behavior/CurrentBehaviorController.js
+++ b/test-e2e/browser/react-app/src/modules/current-behavior/CurrentBehaviorController.js
@@ -1,46 +1,46 @@
 import { Selector } from "@data-provider/core";
-import { connect } from "@data-provider/connector-react";
-import { settings, behaviorsModel, fixturesModel } from "mocks-server-admin-api-client";
+import { withData } from "@data-provider/react";
+import {
+  settings,
+  behaviorsModel,
+  fixturesModel
+} from "@mocks-server/admin-api-client-data-provider";
 
 import CurrentBehaviorView from "./CurrentBehaviorView";
 
 const currentBehavior = new Selector(
   settings,
-  {
-    provider: behaviorsModel,
-    query: (query, prevResults) => {
-      return behaviorsModel.customQueries.byName(prevResults[0].behavior);
-    }
+  (query, prevResults) => {
+    return behaviorsModel.queries.byName(prevResults[0].behavior);
   },
   (settingsResults, behaviorResult) => {
     return behaviorResult;
   },
   {
-    defaultValue: {}
+    initialState: {
+      data: {}
+    }
   }
 );
 
 const currentFixture = new Selector(
   currentBehavior,
-  {
-    provider: fixturesModel,
-    query: (query, prevResults) => {
-      return fixturesModel.customQueries.byId(
-        prevResults[0].fixtures[prevResults[0].fixtures.length - 1]
-      );
-    }
+  (query, prevResults) => {
+    return fixturesModel.queries.byId(prevResults[0].fixtures[prevResults[0].fixtures.length - 1]);
   },
   (currentBehaviorResult, fixtureResult) => {
     return fixtureResult;
   },
   {
-    defaultValue: {}
+    initialState: {
+      data: {}
+    }
   }
 );
 
-const CurrentBehaviorController = connect(() => ({
-  behavior: currentBehavior.read.getters.value,
-  fixture: currentFixture.read.getters.value
-}))(CurrentBehaviorView);
+const CurrentBehaviorController = withData(
+  currentFixture,
+  "fixture"
+)(withData(currentBehavior, "behavior")(CurrentBehaviorView));
 
 export default CurrentBehaviorController;

--- a/test-e2e/browser/react-app/src/modules/current-behavior/CurrentBehaviorView.js
+++ b/test-e2e/browser/react-app/src/modules/current-behavior/CurrentBehaviorView.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { settings } from "mocks-server-admin-api-client";
+import { settings } from "@mocks-server/admin-api-client-data-provider";
 
 const CurrentBehaviorView = ({ behavior, fixture }) => {
   const setBehaviorBase = () => {

--- a/test-e2e/browser/react-app/src/modules/fixtures/FixturesController.js
+++ b/test-e2e/browser/react-app/src/modules/fixtures/FixturesController.js
@@ -1,10 +1,8 @@
-import { connect } from "@data-provider/connector-react";
-import { fixtures } from "mocks-server-admin-api-client";
+import { withData } from "@data-provider/react";
+import { fixtures } from "@mocks-server/admin-api-client-data-provider";
 
 import FixturesView from "./FixturesView";
 
-const FixturesController = connect(() => ({
-  fixtures: fixtures.read.getters.value
-}))(FixturesView);
+const FixturesController = withData(fixtures, "fixtures")(FixturesView);
 
 export default FixturesController;

--- a/test-e2e/browser/react-app/src/modules/settings/SettingsController.js
+++ b/test-e2e/browser/react-app/src/modules/settings/SettingsController.js
@@ -1,10 +1,8 @@
-import { connect } from "@data-provider/connector-react";
-import { settings } from "mocks-server-admin-api-client";
+import { withData } from "@data-provider/react";
+import { settings } from "@mocks-server/admin-api-client-data-provider";
 
 import SettingsView from "./SettingsView";
 
-const SettingsController = connect(() => ({
-  settings: settings.read.getters.value
-}))(SettingsView);
+const SettingsController = withData(settings, "settings")(SettingsView);
 
 export default SettingsController;

--- a/test-e2e/browser/vanilla-app/public/index.html
+++ b/test-e2e/browser/vanilla-app/public/index.html
@@ -7,13 +7,13 @@
     <meta name="description" content="admin-api-client vanilla tests">
     <title>Vanilla App</title>
     <link rel="stylesheet" type="text/css" href="styles.css">
-    <script src="https://unpkg.com/lodash@4.17.15/lodash.min.js"></script>
     <script>
         // TODO, rename lodash global in data-provider/core (Ideally avoid lodash usage)
         window.lodash = window._;
     </script>
+    <script src="https://unpkg.com/redux@4.0.5/dist/redux.js"></script>
     <script src="https://unpkg.com/is-promise@2.1.0/index.js"></script>
-    <script src="https://unpkg.com/@data-provider/core@1.7.0/dist/core.umd.js"></script>
+    <script src="https://unpkg.com/@data-provider/core@2.0.0-alpha.6/dist/core.umd.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/axios/0.18.0/axios.min.js"></script>
     <script src="https://unpkg.com/axios-retry@3.1.2/lib/index.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/path-to-regexp@3.0.0/index.min.js"></script>
@@ -35,7 +35,7 @@
           '(?:\\:(\\w+)(?:\\(((?:\\\\.|[^\\\\()])+)\\))?|\\(((?:\\\\.|[^\\\\()])+)\\))([+*?])?'
         ].join('|'), 'g')
     </script>
-    <script src="https://unpkg.com/@data-provider/axios@1.5.0/dist/data-provider-axios.umd.js"></script>
+    <script src="https://unpkg.com/@data-provider/axios@2.0.0-alpha.2/dist/index.umd.js"></script>
     <script src="https://unpkg.com/@mocks-server/admin-api-paths@1.0.2/dist/index.umd.js"></script>
     <script src="js/admin-api-client.js"></script>
     <script src="https://code.jquery.com/jquery-3.4.1.min.js" crossorigin="anonymous"></script>

--- a/test-e2e/browser/vanilla-app/public/main.js
+++ b/test-e2e/browser/vanilla-app/public/main.js
@@ -1,5 +1,5 @@
 var $ = window.$;
-var adminApiClient = window.mocksServerAdminApiClient;
+var adminApiClient = window.mocksServerAdminApiClientDataProvider;
 var dataProvider = window.dataProvider;
 
 var $behaviorsContainer;
@@ -29,7 +29,9 @@ var currentBehavior = new dataProvider.Selector(
     return behaviorResult;
   },
   {
-    defaultValue: {}
+    initialState: {
+      data: {}
+    }
   }
 );
 
@@ -49,7 +51,9 @@ var currentFixture = new dataProvider.Selector(
     return fixtureResult;
   },
   {
-    defaultValue: {}
+    initialState: {
+      data: {}
+    }
   }
 );
 
@@ -138,15 +142,15 @@ $.when($.ready).then(function() {
     });
   });
 
-  adminApiClient.settings.onClean(function() {
+  adminApiClient.settings.on("cleanCache", function() {
     loadSettings();
   });
 
-  currentBehavior.onClean(function() {
+  currentBehavior.on("cleanCache", function() {
     loadCurrentBehavior();
   });
 
-  currentFixture.onClean(function() {
+  currentFixture.on("cleanCache", function() {
     loadCurrentFixture();
   });
 

--- a/test/src/config.spec.js
+++ b/test/src/config.spec.js
@@ -1,5 +1,5 @@
 import sinon from "sinon";
-import { instances } from "@data-provider/core";
+import { providers } from "@data-provider/core";
 import { DEFAULT_BASE_PATH } from "@mocks-server/admin-api-paths";
 
 import { config } from "../../src/config";
@@ -12,7 +12,7 @@ describe("config method", () => {
   let sandbox;
   beforeAll(() => {
     sandbox = sinon.createSandbox();
-    sandbox.spy(instances.getByTag(TAG), "config");
+    sandbox.spy(providers.getByTag(TAG), "config");
   });
 
   afterAll(() => {
@@ -23,7 +23,7 @@ describe("config method", () => {
     config({
       baseUrl: BASE_URL
     });
-    expect(instances.getByTag(TAG).config.getCall(0).args[0].baseUrl).toEqual(
+    expect(providers.getByTag(TAG).config.getCall(0).args[0].baseUrl).toEqual(
       `${BASE_URL}${DEFAULT_BASE_PATH}`
     );
   });
@@ -33,7 +33,7 @@ describe("config method", () => {
       baseUrl: BASE_URL,
       apiPath: API_PATH
     });
-    expect(instances.getByTag(TAG).config.getCall(1).args[0].baseUrl).toEqual(
+    expect(providers.getByTag(TAG).config.getCall(1).args[0].baseUrl).toEqual(
       `${BASE_URL}${API_PATH}`
     );
   });

--- a/test/src/providers.spec.js
+++ b/test/src/providers.spec.js
@@ -2,7 +2,7 @@ import { behaviorsModel, behavior, fixturesModel, fixture } from "../../src/prov
 
 describe("behaviorsModel findByName custom query", () => {
   it("should return name urlParam", () => {
-    expect(behaviorsModel.test.customQueries.byName("foo")).toEqual({
+    expect(behaviorsModel.queryMethods.byName("foo")).toEqual({
       urlParams: {
         name: "foo"
       }
@@ -12,13 +12,13 @@ describe("behaviorsModel findByName custom query", () => {
 
 describe("behavior alias", () => {
   it("should return queried behaviorsModel", () => {
-    expect(behavior("foo")).toEqual(behaviorsModel.byName("foo"));
+    expect(behavior("foo")).toEqual(behaviorsModel.queries.byName("foo"));
   });
 });
 
 describe("fixturesModel findById custom query", () => {
   it("should return name urlParam", () => {
-    expect(fixturesModel.test.customQueries.byId("foo")).toEqual({
+    expect(fixturesModel.queryMethods.byId("foo")).toEqual({
       urlParams: {
         id: "foo"
       }
@@ -28,6 +28,6 @@ describe("fixturesModel findById custom query", () => {
 
 describe("fixture alias", () => {
   it("should return queried fixturesModel", () => {
-    expect(fixture("foo")).toEqual(fixturesModel.byId("foo"));
+    expect(fixture("foo")).toEqual(fixturesModel.queries.byId("foo"));
   });
 });


### PR DESCRIPTION
### Changed
- chore: Project migrated from @mocks-server/admin-api-client
- chore(deps): [BREAKING CHANGE] Updated @data-provider/core to v2. Not compatible with projects using v1.
- chore(deps): [BREAKING CHANGE] Moved @data-provider/axios dependency to peer-dependencies.
- chore(umd): [BREAKING CHANGE] Renamed umd global variable to "mocksServerAdminApiClientDataProvider"
